### PR TITLE
InitDb: Add missing run configuration

### DIFF
--- a/InitDb.js
+++ b/InitDb.js
@@ -21,6 +21,8 @@ const { connectToDb, getDbReference, closeDbConnection } = require('./lib/mongo'
 const mongoCreateUser = process.env.MONGO_CREATE_USER
 const mongoCreatePassword = process.env.MONGO_CREATE_PASSWORD
 
+console.log("== Calling connectToDb")
+
 connectToDb(async function () {
   /*
    * Insert initial business data into the database

--- a/package.json
+++ b/package.json
@@ -1,4 +1,12 @@
 {
+  "name": "final-project",
+  "version": "1.0.0",
+  "description": "Final Project, resembles an educational platform with students, instructors, admins, courses, etc...",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js",
+    "initdb": "node InitDb.js"
+  },
   "dependencies": {
     "bcrypt": "^5.1.0",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
Previously, the command `docker compose up init-db --build` would fail because there was not a script within the package.json file. It has been added can the docker command now works as expected.