### PR TITLE
Fix errors from mismatched dependency versions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/InitDb.js
+++ b/InitDb.js
@@ -35,10 +35,14 @@ connectToDb(async function () {
    */
   if (mongoCreateUser && mongoCreatePassword) {
     const db = getDbReference()
-    const result = await db.addUser(mongoCreateUser, mongoCreatePassword, {
-      roles: "readWrite"
-    })
-    console.log("== New user created:", result)
+    try {
+      const result = await db.addUser(mongoCreateUser, mongoCreatePassword, {
+        roles: "readWrite"
+      })
+      console.log("== New user created:", result)
+    } catch (err) {
+      console.error("== Failed to create user:", err)
+    }
   }
 
   closeDbConnection(function () {

--- a/app.js
+++ b/app.js
@@ -20,15 +20,10 @@ const rateLimit = require('./lib/ratelimit')
  */
 app.use('/', rateLimit, api)
 
-app.use('*', function (req, res, next) {
+app.use('*', rateLimit, function (req, res, next) {
   res.status(404).json({
     error: "Requested resource " + req.originalUrl + " does not exist"
   })
-})
-
-
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
 })
 
 connectToDb(function () {

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,7 @@ services:
       MONGO_USER: ${MONGO_USER}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
       MONGO_DB_NAME: ${MONGO_DB_NAME}
+      JWT_SECRET: ${JWT_SECRET}
     depends_on:
       - db
       - db-init

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "bcrypt": "^5.1.0",
     "body-parser": "^1.20.2",
-    "express": "^4.18.2",
+    "express": "^4.18.1",
     "jsonwebtoken": "^9.0.0",
-    "mongodb": "^5.6.0",
+    "mongodb": "^4.6.0",
     "multer": "^1.4.5-lts.1"
   }
 }


### PR DESCRIPTION
Our implementation for connecting to db was not compatible with version of mongodb we were depending on, so I downgraded the dependency. As of now, we can now spin up the db, db-init, and api without any errors.